### PR TITLE
Fix code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/chickenpaint/fonts/icomoon/demo-files/demo.js
+++ b/chickenpaint/fonts/icomoon/demo-files/demo.js
@@ -15,7 +15,7 @@ document.body.addEventListener("click", function(e) {
         testDrive = document.getElementById('testDrive'),
         testText = document.getElementById('testText');
     function updateTest() {
-        testDrive.innerHTML = testText.value || String.fromCharCode(160);
+        testDrive.textContent = testText.value || String.fromCharCode(160);
         if (window.icomoonLiga) {
             window.icomoonLiga(testDrive);
         }


### PR DESCRIPTION
Fixes [https://github.com/satopian/ChickenPaint_Be/security/code-scanning/11](https://github.com/satopian/ChickenPaint_Be/security/code-scanning/11)

To fix the problem, we need to ensure that any text assigned to `innerHTML` is properly escaped to prevent it from being interpreted as HTML. This can be achieved by using `textContent` instead of `innerHTML`, which will treat the content as plain text and not HTML.

- Replace the assignment to `innerHTML` with `textContent`.
- Ensure that the functionality remains the same by updating the relevant line in the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
